### PR TITLE
Updates CoolBeans to 2018.12.1

### DIFF
--- a/Casks/coolbeans.rb
+++ b/Casks/coolbeans.rb
@@ -1,6 +1,6 @@
 cask 'coolbeans' do
-  version '2018.12'
-  sha256 '68df6bc7ff63598664e3526492aaf0489ba6a0b0ccf7ac99f726763dd6d1f564'
+  version '2018.12.1'
+  sha256 'ad707c31e3b225de8d67cb961155d998f53b27cbbe4a44d5743997d8bd14c0d5'
 
   url "https://paris.download.coolbeans.xyz/download/CoolBeans-#{version}.dmg"
   appcast 'https://coolbeans.xyz/download-macos.html'


### PR DESCRIPTION
I just updated the version and hash. I guess this would download the dmg properly. Not sure if the app name should be 'CoolBeans #{version}.app' as the .app inside the .dmg is still called CoolBeans to 2018.12. 

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
- [ ] The submission is for [a stable version](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask) or [documented exception](https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#but-there-is-no-stable-version).

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not [already refused].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/Homebrew/homebrew-cask/pulls
[already refused]: https://github.com/Homebrew/homebrew-cask/search?q=is%3Aclosed&type=Issues
[the correct repo]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256